### PR TITLE
Add Trade Chat

### DIFF
--- a/index.js
+++ b/index.js
@@ -326,7 +326,7 @@ SteamTrade.prototype.sendMessage = function(msg, callback) {
     logpos: this._nextLogPos,
     version: this._version
   }, function(status) {
-    callback();
+    if ( typeof callback == "function" ) callback();
   }.bind(this));
 }
 


### PR DESCRIPTION
I have added the function `SteamTrade.sendChatMessage(message, callback)`.  This function sends a message to the trade chat.

It works by sending a POST to `/trade/id/chat` with the `message` parameter set to the message.
